### PR TITLE
Adding Slick.js selector engine

### DIFF
--- a/data.js
+++ b/data.js
@@ -77,6 +77,13 @@ var MicroJS = [
     url: "https://github.com/ded/qwery"
   },
   {
+    name: "Slick",
+    size: "18.0k",
+    tags: ["css"],
+    description: "Best tested selector engine evar. 58+ thousand assertions passing in all browsers. CSS1–CSS3 selectors & custom extensions like 'reverse combinators'.",
+    url: "http://mootools.net/core/9e15b95be69c7c57e6afddf823c03857"
+  },
+  {
     name: "Sly",
     size: "3.0k",
     tags: ["css"],


### PR DESCRIPTION
Actually, Slick1.x can be minified as small as 13k, but that's still a little too chubby to compete with Qwery and Sly on the k-count. Slick2 will be a lot smaller and more modular.
Updated: 6.12792969 kilobytes min+gzip
Updated again: 5.47558594 kilobytes when compressed with Closure Compiler default,
5.08496094 kilobytes with closure compiler ADVANCED_OPTIMIZATIONS
