### PR TITLE
Add thumbs.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -589,5 +589,13 @@ var MicroJS = [
     description: "A formfactor detection library, to help developers target tablet, tvs, desktops and handhelds (or anything you choose)",
     url: "http://formfactorjs.com",
     source: "http://github.com/PaulKinlan/formfactor/raw/master/formfactor-min.js"
+  },
+  {
+    name: "thumbs.js",
+    size: "0.6k",
+    tags: ["polyfill"],
+    description: "Add touch event support to the desktop and other mouse-based browsers.",
+    url: "http://mwbrooks.github.com/thumbs.js/",
+    source: "https://github.com/mwbrooks/thumbs.js/blob/master/lib/thumbs.js"
   }
 ];


### PR DESCRIPTION
A polyfill that adds basic touch event support to touch-less browsers. This is a useful library when testing mobile applications on the desktop or supporting a broad range of mobile devices (touch and trackball-based). This was created by a few of the PhoneGap team members.
