### PR TITLE
correct size of jsonselect is 1.9k, not 2.7k

### DIFF
--- a/data.js
+++ b/data.js
@@ -774,7 +774,7 @@ var MicroJS = [
   },
   {
     name: "JSONSelect",
-    size: "2.7k",
+    size: "1.9k",
     tags: ["data", "json"],
     description: "CSS-like selectors for JSON.",
     url: "http://jsonselect.org"


### PR DESCRIPTION
```
$ ls -lh jsonselect.js 
-rw-r--r-- 1 lth users 8.3K May 23 10:26 jsonselect.js
$ yuimin jsonselect.js > jsonselect.min.js 
$ ls -lh jsonselect.min.js 
-rw-r--r-- 1 lth users 4.4K May 23 11:07 jsonselect.min.js
$ gzip jsonselect.min.js 
$ ls -lh jsonselect.min.js.gz 
-rw-r--r-- 1 lth users 1.9K May 23 11:07 jsonselect.min.js.gz
```
