### PR TITLE
Replaced GSet tag "base" with "compose"

### DIFF
--- a/data.js
+++ b/data.js
@@ -2,7 +2,7 @@ var MicroJS = [
   {
     name: "GSet",
     size: "1.8k",
-    tags: ["data", "base"],
+    tags: ["data", "compose"],
     description: "Share and control public proxies of private objects, with same-name getter/setters.",
     url: "https://github.com/bemson/GSet/",
     source: "https://github.com/bemson/GSet/raw/master/gset-min.js"


### PR DESCRIPTION
Hi again,

After reading the message from my last pull-request, I realized that "compose" was the best tag available. My apologies for requesting such a menial change, and many thanks in advance.

Again, if you can create any kind of "object" tags, as in "I need a constructor object", GSet would fit nicely.

\- best,

bemson
