### PR TITLE
Explicitly set option background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,9 @@
     color: #fff;
     padding: 3px;
   }
+  option {
+    background: #000;
+  }
   ul {
     list-style-type: none;
     width: 650px;


### PR DESCRIPTION
Just happened to notice the menu in Chromium 12 on Ubuntu 10.10 was illegible (light background, white font). It looks fine on Firefox (on Ubuntu), so I'm guessing it has to do with the way the select and options are rendered in Chromium, and the specification that CSS background properties are not inherited. Maybe it's an edge case, but the simple fix is to explicitly set the background color for the options.
