### PR TITLE
Fixed the extend.js URL after changing it

### DIFF
--- a/data.js
+++ b/data.js
@@ -831,10 +831,10 @@ var MicroJS = [
   {
     name: "extend.js",
     size: "0.6k",
-    tags: ["namespace", "extend"],
+    tags: ["base", "language", "feature"],
     description: "A simple way to define and extend namespaces",
     url: "https://github.com/searls/extend.js",
-    source: "https://raw.github.com/searls/extend.js/master/lib/extend.0.0.1.min.js"
+    source: "https://raw.github.com/searls/extend.js/master/lib/extend-min.js"
   },
   {
     name: "System.js",


### PR DESCRIPTION
Used to include version number in the URL, but don't want to issue a pull request here each time that I do, so I've removed the version number from the filename. (will be a broken link until this pull request is merged in)
