### PR TITLE
Added one-color

### DIFF
--- a/data.js
+++ b/data.js
@@ -9,6 +9,14 @@
 
 var MicroJS = [
   {
+    name: "one-color",
+    size: "2.0k",
+    tags: ["color"],
+    description: "Browser/node color library. Implicit color space conversions, chainable channel methods and CSS convenience methods. RGB, HSV, HSL, CMYK with alpha channel",
+    url: "https://github.com/One-com/one-color",
+    source: "https://raw.github.com/One-com/one-color/master/one-color-debug.js"
+  },
+  {
     name: "TinyDOM",
     size: "1.4k",
     tags: ["dom"],


### PR DESCRIPTION
`one-color` is a browser and node color library. At 2.0k minified and gzipped, it has:
- RGB, HSL, HSV color space support with alpha channel
- Chainable color channel methods
- Implicit color space conversions
- CSS string parser and CSS convenience methods
- Optional CMYK color space with https://github.com/One-com/one-color/blob/master/lib/one/color/CMYK.js
- Ender.js support
- Extensible architecture, new color spaces easily implemented
