### PR TITLE
Added server2.js libray

### DIFF
--- a/data.js
+++ b/data.js
@@ -195,6 +195,16 @@ var MicroJS = [
                      // we overrule the sanity-check that compares the sizes and would otherwise reject this
   },
   {
+    name: "server2.js",
+    tags: ["server", "pubsub", "events", "base"],
+    description: "A hook based interface between your server and your JS application",
+    url: "https://github.com/thanpolas/server2js",
+    source: "https://github.com/thanpolas/server2js/raw/master/source/server2.js",
+    tinyminify: true 
+          // this source has a ton of comments so the minified version is tiny compared to raw, so
+          // we overrule the sanity-check that compares the sizes and would otherwise reject this
+  },  
+  {
     name: "MinPubSub",
     tags: ["events", "pubsub"],
     description: "A publish/subscribe messaging framework",


### PR DESCRIPTION
[server2.js](https://github.com/thanpolas/server2js) was written with optimizations for the closure compiler.

The [bare source](https://github.com/thanpolas/server2js/blob/master/source/server2.js) file is ~10kb, and when [it is build](https://github.com/thanpolas/server2js/blob/master/build/server2js.concatenated.js) it becomes ~58kb.

However, closure compiler does its magic and [generates](https://github.com/thanpolas/server2js/blob/master/dist/server2.min.js) a 2,659 bytes (1,078 bytes gzipped) file.

Thank you for the consideration
