### PR TITLE
Add nwt - a tiny javascript framework.

### DIFF
--- a/data.js
+++ b/data.js
@@ -1931,5 +1931,13 @@ var MicroJS = [
     description: "A small, fast and reliable library for arbitrary-precision arithmetic with decimal numbers.",
     url: "https://github.com/MikeMcl/big.js/",
     source: "https://raw.github.com/MikeMcl/big.js/master/big.js"
+  },
+  {
+    name: "nwt",
+    github: "nwtjs/nwt",
+    tags: ["base", "dom", "webkit", "ajax", "events", "mobile", "animation", "transitions"],
+    description: "Small JS framework that ships with ajax, anim, dom, and event methods. Several plugins available.",
+    url: "http://nwtjs.org",
+    source: "https://raw.github.com/nwtjs/nwt/master/nwt.js"
   }
 ];


### PR DESCRIPTION
Nwt is a tiny javascript framework which ships with ajax, dom, event and transition methods at under 5kb.

I noticed you have another outstanding pull request which may create a merge conflict. If you'd like me to resubmit this one afterwards or take care of any merge conflicts let me know.
