### PR TITLE
Adding the Perms module

### DIFF
--- a/data.js
+++ b/data.js
@@ -2026,5 +2026,12 @@ var MicroJS = [
     description: "Chic is an extremely simple class-like interface to JavaScript prototypal inheritance.",
     url: "https://github.com/rowanmanning/chic",
     source: "https://raw.github.com/rowanmanning/chic/master/lib/chic.js"
+  },
+  {
+    name: "Perms",
+    tags: ["permissions", "perms", "ls", "chmod", "unix"],
+    description: "Convert Unix style permissions to strings like ls (0755 => 'rwxr-xr-x')",
+    url: "https://github.com/bahamas10/node-perms",
+    source: "https://raw.github.com/bahamas10/node-perms/master/index.js"
   }
 ];


### PR DESCRIPTION
![Screen Shot 2012-12-08 at 7.12.58 PM.png](https://f.cloud.github.com/assets/1205722/2184/656d7412-41ae-11e2-8b40-8a4e56e9be39.png)

Check out the module here https://github.com/bahamas10/node-perms#perms

Originally written with just Node in mind, but it has no dependencies at all, so it will work in any javascript environment.

I recently used this module for a Unix tutorial/game website where the user was given a permission string like `rwxr-xr-x`, and had to provide the correct octal permissions (`0755`). This module converts between the two.
