### PR TITLE
Add remove.js to the list.

### DIFF
--- a/data.js
+++ b/data.js
@@ -9,6 +9,14 @@
 
 var MicroJS = [
    {
+    name: "remove.js",
+    github: "scrapmac/snippets/tree/master/remove.js",
+    tags: ["string", "remove", "cleanup", "redundant", "gibberish", "trim"],
+    description: "Small but powerful string cleanup and reduction library.",
+    url: "https://github.com/scrapmac/snippets/tree/master/remove.js",
+    source: "https://github.com/scrapmac/snippets/raw/master/remove.js/remove.js"
+   },
+   {
     name: "ImageFlip.js",
     github: "erf/ImageFlip.js",
     tags: ["slideshow", "images", "gallery", "collage"],


### PR DESCRIPTION
remove.js is a small library which provides string cleanup methods. It can work with node `npm instal remove.js` or standalone browser script, or if you have jQuery, it attaches methods so that you can do `$([String Array]).rG().rR().rC(10)` . More info at https://github.com/scrapmac/snippets/tree/master/remove.js
