### PR TITLE
added jsFlow

### DIFF
--- a/data.js
+++ b/data.js
@@ -1002,6 +1002,13 @@ var MicroJS = [
     source: "https://raw.github.com/tinyhippos/jWorkflow/master/lib/jWorkflow.js"
   },
   {
+    name: "jsFlow",
+    tags: ["functional", "workflow", "async","data", "games", "statemachine"],
+    description: "A simple library to define and run modular, reusable, dynamic flow modules (100% jWorkflow API compatibility)",
+    url: "https://github.com/Tapsi/jsFlow",
+    source: "https://raw.github.com/Tapsi/jsFlow/master/lib/jsFlow.js"
+  },
+  {
     name: "Events.js",
     tags: ["events", "dom"],
     description: "Cross-browser DOM events, with keystroke handling, hashchange, mouseenter/leave.",


### PR DESCRIPTION
Hello I want to add my `jsFlow` library here. It's a fork of jWorkflow with a lot of enhancements and new features. It uses the original design of defining flows by extending it for more use cases like dynamic flow execution and state machines.

It's still a very small library ( which is one of it's goals ). 

The library has following size stats:

Core (without state machine factory helper) 
Normal 6.1KB
Minified 2.3KB
Goolge Gzip ~0.9KB 

Full:
Normal 7.3KB
Minified 2.9KB
Goolge Gzip ~1.8KB 
