### PR TITLE
Added PerfNow.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -17,6 +17,13 @@ module.exports = [
     source: "https://raw2.github.com/amwmedia/infect.js/master/infect.js"
   },
   {
+    name: "PerfNow.js",
+    tags: ["performance", "benchmark", "polyfill", "high", "resolution", "timer", "now"],
+    description: "A high resolution performance benchmarking polyfill",
+    url: "https://github.com/daniellmb/perfnow.js",
+    source: "https://raw.github.com/daniellmb/perfnow.js/master/perfnow.src.js"
+  },
+  {
     name: "Sortable",
     github: "RubaXa/Sortable",
     tags: ["sortable", "dnd", "reorder", "drag", "touch"],


### PR DESCRIPTION
_A 116 byte window.performance.now high resolution timer polyfill with Date fallback._
## Tested Environments
- Mac OS X
  - Google Chrome
  - Safari
  - Firefox
  - Opera
- Windows
  - Google Chrome
  - Safari
  - Firefox
  - Opera
  - Internet Explorer
## How to use

``` javascript
var t0 = performance.now();
doSomething();
var t1 = performance.now();
console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
```

[https://github.com/daniellmb/perfnow.js](https://github.com/daniellmb/perfnow.js)
## Why?

Unlike other timing data available to JavaScript (for example `Date.now`), the timestamps returned by `Performance.now()` are not limited to one-millisecond resolution. Instead, they represent times as floating-point numbers with up to microsecond precision.

Also unlike `Date.now`, the values returned by `Performance.now()` always increase at a constant rate, independent of the system clock which might be adjusted manually or skewed by software such as the Network Time Protocol.
## When?

There are a many situations where you should use this high resolution timer instead of a basic timestamp:
- **benchmarking**
- calculating framerate with precision
- cueing actions or audio to occur at specific points in an animation or other time-based sequence
- game or animation runloop code
