### PR TITLE
Add pathparser.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -1599,6 +1599,13 @@ module.exports = [
     source: "https://raw.githubusercontent.com/mwbrooks/thumbs.js/master/lib/thumbs.js"
   },
   {
+    name: "pathparser.js",
+    tags: ["route", "routing", "query", "parameters"],
+    description: "Tiny, simple-to-use URL parser/router",
+    url: "https://github.com/dstillman/pathparser.js",
+    source: "https://raw.githubusercontent.com/dstillman/pathparser.js/master/pathparser.js"
+  },
+  {
     name: "DOMBuilder",
     tags: ["dom", "html"],
     description: "Declarative builder with (mostly) interchangeable DOM or HTML output",


### PR DESCRIPTION
Yet another router, but this one is smaller (700 bytes minified/gzipped) and IMO a bit easier to use than most. It's most similar to Rlite, but treats named parameters as optional (allowing fewer routes), doesn't allow query parameters to override named parameters, and doesn't require parameters to be dealt with manually in handlers.
