### PR TITLE
Add simple-require-loader

### DIFF
--- a/data.js
+++ b/data.js
@@ -5120,5 +5120,12 @@ module.exports = [
     description: "boomerangCache is a client side caching library based on localStorage and sessionStorage",
     url: "http://giraysam.github.io/boomerang-cache/",
     source: "https://raw.githubusercontent.com/giraysam/boomerang-cache/master/src/boomerang-cache.js"
+  },
+  {
+    name: "simple-require-loader",
+    tags: ["loader", "spa", "cross-platform"],
+    description: "A simple, dynamic, powerful module loader with hot swapping and optional remote loading support.",
+    url: "https://github.com/isiahmeadows/simple-require-loader",
+    source: "https://cdn.rawgit.com/isiahmeadows/simple-require-loader/v0.1.0/r.js"
   }
 ];


### PR DESCRIPTION
It's literally a 528-byte fully-featured module loader (a la AMD or CommonJS), but has a ton of features, including cross-platform, async remote loading support in both the browser environment and workers. Another version (not directly linked here) is 340 bytes, and doesn't include remote loading support (but it has everything else).