### PR TITLE
add body-scroll-freezer.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -66,6 +66,14 @@ module.exports = [
     source: "https://raw.githubusercontent.com/unicorn-standard/uniloc/master/uniloc.js"
   },
   {
+    name: "body-scroll-freezer.js",
+    github: "ramonvictor/body-scroll-freezer",
+    tags: ["scroll", "freeze", "modal", "scrolling", "lightbox", "performance"],
+    description: "Dependency-free JS module to freeze body scroll when opening modal box",
+    url: "https://github.com/ramonvictor/body-scroll-freezer",
+    source: "https://raw.githubusercontent.com/ramonvictor/body-scroll-freezer/master/src/body-scroll-freezer.js"
+  },
+  {
     name: "MagJS",
     github: "magnumjs/mag.js",
     tags: ["mvc framework", "mvc", "framework", "templating", "library", "component", "fast", "simple", "clean"],


### PR DESCRIPTION
Dependency-free JS module to freeze body scroll when opening modal box.

This module solves a small scroll default behaviour problem without causing performance side-effects on the browser. 

More info can be found [here](https://github.com/ramonvictor/body-scroll-freezer/).