### PR TITLE
fixed broken script stats.js

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -4,6 +4,7 @@ const path    = require('path')
     , strings = require('./strings')
 
 function stats (config) {
+  var RESERVED_ATTRIBUTE_NAMES = ['constructor']
   var data      = require(path.join(__dirname, '..', config.inFile))
     , byTag     = {}
     , byCount   = {}
@@ -12,6 +13,9 @@ function stats (config) {
     , contents  = String(fs.readFileSync('index.html', 'utf-8'))
     , mainTags  = String(contents).match(optReg).map(function (o) { return o.match(new RegExp(optReg.source))[1] })
     , pushTag   = function (hash, tag, d) {
+        if (RESERVED_ATTRIBUTE_NAMES.indexOf(tag.toLowerCase()) !== -1) {
+          return
+        }
         (hash[tag] || (hash[tag] = [])).push(d)
       }
 


### PR DESCRIPTION
Cannot run command:
``` shell
./build.js -s
```
Script was broken because one library in data.js declared  `constructor` as a tag value.