### PR TITLE
fixed ghauth in order to support "skip stats collection"

### DIFF
--- a/lib/ghauth.js
+++ b/lib/ghauth.js
@@ -77,12 +77,18 @@ function auth (config, callback) {
     if (err)
       return callback(err)
 
-    createAuth(config, function (err) {
-      if (err)
-        return callback(err)
-      fs.writeFileSync(configPath, JSON.stringify({ user: config.ghUser, token: config.ghToken }), 'utf8')
+    if (config.ghUser) {
+      createAuth(config, function (err) {
+        if (err)
+          return callback(err)
+        fs.writeFileSync(configPath, JSON.stringify({ user: config.ghUser, token: config.ghToken }), 'utf8')
+        callback()
+      })
+    } else {
+      console.log('skipped stats collection')
+      console.log()
       callback()
-    })
+    }
   })
 }
 


### PR DESCRIPTION
When running command
```shell
./build.js -v
```
The Github username is prompted and a comment tells:
```shell
Leave the username field blank to skip stats collection.
```
My PR handles this use case.
