### PR TITLE
Remove defunct TinyDOM (404)

### DIFF
--- a/data.js
+++ b/data.js
@@ -1445,13 +1445,6 @@ module.exports = [
     source: "https://raw.githubusercontent.com/mourner/simplify-js/master/simplify.js"
   },
   {
-    name: "TinyDOM",
-    tags: ["dom"],
-    description: "A very small DOM manipulation framework",
-    url: "https://github.com/ctult/TinyDOM",
-    source: "https://raw.githubusercontent.com/ctult/TinyDOM/master/tinyDOM.js"
-  },
-  {
     name: "DOMpteur",
     github: "SimonWaldherr/DOMpteur",
     tags: ["dom", "ready", "html", "getElement", "selector"],


### PR DESCRIPTION
TinyDOM's github repo is gone (404): https://github.com/ctult/TinyDOM

I can't find a maintained fork so I suggest removal.