### PR TITLE
Add canary to list of packages

### DIFF
--- a/data.js
+++ b/data.js
@@ -261,6 +261,16 @@ module.exports = [{
     source: "https://raw.githubusercontent.com/AtSpy/AtSpy/master/dist/atspy.js"
   },
   {
+    name: "Canary",
+    github: "Mapita/Canary",
+    tags: ["javascript", "test", "tests", "testing", "unit test", "unit tests", "unit testing", "automated test", "automated tests", "automated testing"],
+    description: "Write and run unit tests.",
+    url: "https://github.com/Mapita/Canary",
+    package: "canary-test",
+    documentation: "http://canary.readthedocs.io/en/stable/",
+    source: "https://github.com/Mapita/Canary/blob/master/canary.js"
+  },
+  {
     name: "FrontExpress",
     github: "camelaissani/frontexpress",
     tags: ["frontexpress", "router", "routing", "express", "spa", "framework", "front-end", "tiny", "parameters", "querystring", "named", "path", "uri"],


### PR DESCRIPTION
I ran into some confusion when trying to determine whether Canary was within the 5kb size limit.

I used [uglify-es](https://www.npmjs.com/package/uglify-es) to produce this result, just over 5kb:

```
sophie:canary pineapple$ uglifyjs canary.js | gzip -9f | wc -c
    5169
```

This surprised me, so I looked at the uglify output. It turns out uglify-es doesn't mangle argument and variable names. I did some mangling manually and was able to reduce the output size by 80 bytes well before I was halfway through the source, which leads me to believe that the output would be under 5kb with an uglifier that knew what it was doing.

I found I could reduce the size pretty easily and significantly by removing some logged lines - since it's a test runner, and understanding failures is very important, the verbose setting in particular can be used to make it log a _lot_ of information  - I experimentally removed all of the messages logged only on the verbose setting and it reduced the (unmangled) output size by a whole 1kb. Hopefully this can be considered in deciding whether the flat slightly >5kb output disqualifies Canary from inclusion?

Microjs is cool and I'd really like for Canary to be included, but it wouldn't make sense for me to go mangling argument and variable names in the original source, or to strip log lines from it just to get under the limit. I hope that there can be some flexibility, if the authoritative count is different from my own.

Also:

When I ran `build.js` the Canary entry failed with this error. But a lot of other entries failed with similar errors too. I don't know if I did something wrong, or if this is an issue with the build script? Possibly it's due to Canary using ES6 syntax like template strings and async/await?

```
ERROR:   Canary               Uglify error: Unexpected token: operator (<)
```

And one more thing...

I added extra `documentation` and `package` fields to this entry (links to readthedocs and the name of the package on npm, respectively) since hopefully there isn't any harm in it and it seems vaguely possible that this information could be useful to somebody.
