### PR TITLE
Add Apt.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -37,7 +37,7 @@ module.exports = [
     tags: ["browser", "embeddable", "loader", "base", "dom", "micro", "framework", "require"],
     description: "Minimalist, fast, rather-slim and pretty concise framework/library. Provides the flavour of both jQuery and RequireJS without the payload. Small enough to be embedded in any first-byte.",
     url: "https://github.com/frqnck/apt.js",
-    source: "https://github.com/frqnck/apt.js/blob/master/dist/apt.js"
+    source: "https://github.com/frqnck/apt.js/blob/master/src/apt-core.js"
   },
   {
     name: "ShadowQuery",

--- a/data.js
+++ b/data.js
@@ -32,6 +32,14 @@ module.exports = [
     source: "https://raw.githubusercontent.com/wisniewski94/sprites.js/master/sprites.js"
   },
   {
+    name: "apt.js",
+    github: "frqnck/apt.js",
+    tags: ["browser", "embeddable", "loader", "base", "dom", "micro", "framework", "require"],
+    description: "Minimalist, fast, rather-slim and pretty concise framework/library. Provides the flavour of both jQuery and RequireJS without the payload. Small enough to be embedded in any first-byte.",
+    url: "https://github.com/frqnck/apt.js",
+    source: "https://github.com/frqnck/apt.js/blob/master/dist/apt.js"
+  },
+  {
     name: "ShadowQuery",
     github: "schrotie/shadow-query",
     tags: ["web-components"],


### PR DESCRIPTION
:rocket: Apt.js – a few bytes long in-browser library, jQuery and RequireJS without the payload