### PR TITLE
Please add FastestSmallestTextEncoderDecoder; BestBase64EncoderDecoder; Fast Map, WeakMap, Set, and WeakSet Polyfill; SuperSimpleExtensibleSmallXMLHttpRequestWrapper; Force DOM reflow JS; DeferStackJS; AsyncGlobalEvalFunction; and SPromiseMeSpeed

### DIFF
--- a/data.js
+++ b/data.js
@@ -4102,6 +4102,70 @@ module.exports = [
     source: "https://cdn.jsdelivr.net/npm/domtastic@latest/dist/domtastic.js"
   },
   {
+    name: "FastestSmallestTextEncoderDecoder",
+    github: "anonyco/FastestSmallestTextEncoderDecoder",
+    tags: ["utf-8", "encoding", "decoding", "browser", "node-js", "polyfill"],
+    description: "The fastest smallest Javascript polyfill for the encode of TextEncoder and decode of TextDecoder for UTF-8 only",
+    url: "https://anonyco.github.io/FastestSmallestTextEncoderDecoder/gh-pages/",
+    source: "https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0"
+  },
+  {
+    name: "BestBase64EncoderDecoder",
+    github: "anonyco/BestBase64EncoderDecoder",
+    tags: ["btoa", "atob", "utf-8", "browser", "node-js"],
+    description: "The most standard, most cross-browser, most compact, and fastest possible btoa and atob solution for unicode strings with high code points",
+    url: "https://anonyco.github.io/BestBase64EncoderDecoder/demo.html",
+    source: "https://dl.dropboxusercontent.com/s/uo9kbpolhnat1cg/atobAndBtoaTogether.min.js?dl=0"
+  },
+  {
+    name: "Fast Map, WeakMap, Set, and WeakSet Polyfill",
+    github: "anonyco/Javascript-Fast-Light-Map-WeakMap-Set-And-WeakSet-JS-Polyfill",
+    tags: ["polyfill", "map", "weakmap-polyfill", "map-polyfill", "weakset-polyfill", "set-polyfill", "es6", "browser"],
+    description: "A fast, lightweight, Javascript Map and WeakMap polyfill",
+    url: "https://github.com/anonyco/Javascript-Fast-Light-Map-WeakMap-Set-And-WeakSet-JS-Polyfill",
+    source: "https://dl.dropboxusercontent.com/s/mxu7cxl5ubh3t3t/mapPolyfillv2.min.js?dl=0"
+  },
+  {
+    name: "SuperSimpleExtensibleSmallXMLHttpRequestWrapper",
+    github: "anonyco/SuperSimpleExtensibleSmallXMLHttpRequestWrapper",
+    tags: ["xmlhttprequest", "http", "xmlhttprequest-wrapper", "browser"],
+    description: "A 338-byte super small, simple, light, fast, XMLHttpRequest wrapper",
+    url: "https://github.com/anonyco/SuperSimpleExtensibleSmallXMLHttpRequestWrapper",
+    source: "https://dl.dropboxusercontent.com/s/y9muahvy3m8bsp6/superxhr.min.js?dl=0"
+  },
+  {
+    name: "Force DOM reflow JS",
+    github: "anonyco/Force-DOM-reflow-JS",
+    tags: ["dom-reflow", "css-transitions", "browser"],
+    description: "The cross-browser force DOM reflow library that will work in all current and future browsers",
+    url: "https://github.com/anonyco/Force-DOM-reflow-JS",
+    source: "https://raw.githubusercontent.com/anonyco/Force-DOM-reflow-JS/master/forceReflow.min.js"
+  },
+  {
+    name: "DeferStackJS",
+    github: "anonyco/DeferStackJS",
+    tags: ["deferred-tasks", "trampoline", "node-js", "browser"],
+    description: "A small fast library that solves the 'Maximum Stack Call Exceeded' error",
+    url: "https://github.com/anonyco/DeferStackJS",
+    source: "https://dl.dropboxusercontent.com/s/wvwyrzx557eqi0v/DeferStack.min.js?dl=0"
+  },
+  {
+    name: "AsyncGlobalEvalFunction",
+    github: "anonyco/AsynchronousEvalFunction",
+    tags: ["eval", "asynchronous", "global", "node-js", "browser"],
+    description: "A simple way to asynchronously defer execution of code stored in a string to prevent execution thread blockage",
+    url: "https://github.com/anonyco/AsynchronousEvalFunction",
+    source: "https://raw.githubusercontent.com/anonyco/AsynchronousEvalFunction/master/AsyncGlobalEvalFunction.src.js"
+  },
+  {
+    name: "SPromiseMeSpeed",
+    github: "anonyco/SPromiseMeSpeedJS",
+    tags: ["speed-polyfill", "polyfill", "promise", "Promises/A+", "asynchronous", "es6", "node-js", "browser"],
+    description: "The javascript library that promises you the fastest ES6 promises",
+    url: "https://anonyco.github.io/SPromiseMeSpeedJS/PromiseMeSpeed.test.html",
+    source: "https://dl.dropboxusercontent.com/s/i8om2fcz5izdeoj/PromiseMeSpeed.min.js?dl=0"
+  },
+  {
     name: "Timer.js",
     tags: ["interval", "timeout", "timer", "periodic"],
     description: "Timer.js is a periodic timer for Node.js and the browser.",

--- a/data.js
+++ b/data.js
@@ -4107,7 +4107,7 @@ module.exports = [
     tags: ["utf-8", "encoding", "decoding", "browser", "node-js", "polyfill"],
     description: "The fastest smallest Javascript polyfill for the encode of TextEncoder and decode of TextDecoder for UTF-8 only",
     url: "https://anonyco.github.io/FastestSmallestTextEncoderDecoder/gh-pages/",
-    source: "https://dl.dropboxusercontent.com/s/r55397ld512etib/EncoderDecoderTogether.min.js?dl=0"
+    source: "https://raw.githubusercontent.com/anonyco/FastestSmallestTextEncoderDecoder/master/EncoderDecoderTogether.src.js"
   },
   {
     name: "BestBase64EncoderDecoder",
@@ -4115,7 +4115,7 @@ module.exports = [
     tags: ["btoa", "atob", "utf-8", "browser", "node-js"],
     description: "The most standard, most cross-browser, most compact, and fastest possible btoa and atob solution for unicode strings with high code points",
     url: "https://anonyco.github.io/BestBase64EncoderDecoder/demo.html",
-    source: "https://dl.dropboxusercontent.com/s/uo9kbpolhnat1cg/atobAndBtoaTogether.min.js?dl=0"
+    source: "https://raw.githubusercontent.com/anonyco/BestBase64EncoderDecoder/master/atobAndBtoaTogether.src.js"
   },
   {
     name: "Fast Map, WeakMap, Set, and WeakSet Polyfill",
@@ -4123,7 +4123,7 @@ module.exports = [
     tags: ["polyfill", "map", "weakmap-polyfill", "map-polyfill", "weakset-polyfill", "set-polyfill", "es6", "browser"],
     description: "A fast, lightweight, Javascript Map and WeakMap polyfill",
     url: "https://github.com/anonyco/Javascript-Fast-Light-Map-WeakMap-Set-And-WeakSet-JS-Polyfill",
-    source: "https://dl.dropboxusercontent.com/s/mxu7cxl5ubh3t3t/mapPolyfillv2.min.js?dl=0"
+    source: "https://raw.githubusercontent.com/anonyco/Javascript-Fast-Light-Map-WeakMap-Set-And-WeakSet-JS-Polyfill/master/mapPolyfill.src.js"
   },
   {
     name: "SuperSimpleExtensibleSmallXMLHttpRequestWrapper",
@@ -4131,7 +4131,7 @@ module.exports = [
     tags: ["xmlhttprequest", "http", "xmlhttprequest-wrapper", "browser"],
     description: "A 338-byte super small, simple, light, fast, XMLHttpRequest wrapper",
     url: "https://github.com/anonyco/SuperSimpleExtensibleSmallXMLHttpRequestWrapper",
-    source: "https://dl.dropboxusercontent.com/s/y9muahvy3m8bsp6/superxhr.min.js?dl=0"
+    source: "https://raw.githubusercontent.com/anonyco/SuperSimpleExtensibleSmallXMLHttpRequestWrapper/master/superxhr.src.js"
   },
   {
     name: "Force DOM reflow JS",
@@ -4139,7 +4139,7 @@ module.exports = [
     tags: ["dom-reflow", "css-transitions", "browser"],
     description: "The cross-browser force DOM reflow library that will work in all current and future browsers",
     url: "https://github.com/anonyco/Force-DOM-reflow-JS",
-    source: "https://raw.githubusercontent.com/anonyco/Force-DOM-reflow-JS/master/forceReflow.min.js"
+    source: "https://anonyco.github.io/Force-DOM-reflow-JS/forceReflow.src.js"
   },
   {
     name: "DeferStackJS",
@@ -4147,7 +4147,7 @@ module.exports = [
     tags: ["deferred-tasks", "trampoline", "node-js", "browser"],
     description: "A small fast library that solves the 'Maximum Stack Call Exceeded' error",
     url: "https://github.com/anonyco/DeferStackJS",
-    source: "https://dl.dropboxusercontent.com/s/wvwyrzx557eqi0v/DeferStack.min.js?dl=0"
+    source: "https://anonyco.github.io/DeferStackJS/DeferStack.src.js"
   },
   {
     name: "AsyncGlobalEvalFunction",
@@ -4163,7 +4163,23 @@ module.exports = [
     tags: ["speed-polyfill", "polyfill", "promise", "Promises/A+", "asynchronous", "es6", "node-js", "browser"],
     description: "The javascript library that promises you the fastest ES6 promises",
     url: "https://anonyco.github.io/SPromiseMeSpeedJS/PromiseMeSpeed.test.html",
-    source: "https://dl.dropboxusercontent.com/s/i8om2fcz5izdeoj/PromiseMeSpeed.min.js?dl=0"
+    source: "https://anonyco.github.io/SPromiseMeSpeedJS/SPromiseMeSpeed.src.js"
+  },
+  {
+    name: "Highlighter-JS",
+    github: "anonyco/Highlighter-JS",
+    tags: ["functional", "es6", "node-js", "browser"],
+    description: "Simple, small, fast, multilingual text highlighter in javascript.",
+    url: "https://github.com/anonyco/Highlighter-JS",
+    source: "https://raw.githubusercontent.com/anonyco/Highlighter-JS/master/highlighter.src.js"
+  },
+  {
+    name: "IDL-Property-Observer",
+    github: "anonyco/IDL-Property-Observer",
+    tags: ["mutation-observer", "evil", "es6", "browser"],
+    description: "Plug changes like HTMLInputElement.value into MutationObservers in 766 bytes. Framework agnostic!.",
+    url: "https://github.com/anonyco/anonyco/IDL-Property-Observer",
+    source: "https://raw.githubusercontent.com/anonyco/IDL-Property-Observer/master/IDLPropertyObserver.src.js"
   },
   {
     name: "Timer.js",

--- a/data.js
+++ b/data.js
@@ -4162,7 +4162,7 @@ module.exports = [
     github: "anonyco/SPromiseMeSpeedJS",
     tags: ["speed-polyfill", "polyfill", "promise", "Promises/A+", "asynchronous", "es6", "node-js", "browser"],
     description: "The javascript library that promises you the fastest ES6 promises",
-    url: "https://anonyco.github.io/SPromiseMeSpeedJS/PromiseMeSpeed.test.html",
+    url: "https://github.com/anonyco/SPromiseMeSpeedJS",
     source: "https://anonyco.github.io/SPromiseMeSpeedJS/SPromiseMeSpeed.src.js"
   },
   {
@@ -4178,7 +4178,7 @@ module.exports = [
     github: "anonyco/IDL-Property-Observer",
     tags: ["mutation-observer", "evil", "es6", "browser"],
     description: "Plug changes like HTMLInputElement.value into MutationObservers in 766 bytes. Framework agnostic!.",
-    url: "https://github.com/anonyco/anonyco/IDL-Property-Observer",
+    url: "https://github.com/anonyco/IDL-Property-Observer",
     source: "https://raw.githubusercontent.com/anonyco/IDL-Property-Observer/master/IDLPropertyObserver.src.js"
   },
   {


### PR DESCRIPTION
I have included the minified files instead of the source files because Closure Compiler is so much better than UglifyJS (especially for the way in which I code Javascript) that the representation of the size by UglifyJS would be completely unfair. For example, I use a DEBUGMODE switch variable in SPromiseMeSpeed to easily differentiate and distribute two separate versions of the library. UglifyJS is simply too primitive to properly optimize this Javascript code so completely as Closure Compiler can.  In the "Rules" section, you say that "hand-optimized" code is preferred. Well, I could spent an infinite amount of time hand-optimizing the minified size of my libraries and still not beat Closure Compiler. Even after much scrutiny on every minified file, the only three problem I have yet to find are that `typeof global==="undefined"` is not transformed into `typeof global==void 0`, `Infinity` is not transformed into `1/0`, and `NaN` is not transformed into `0/0`. I submitted these bugs to the [Closure Compiler repository](https://github.com/google/closure-compiler/issues/2934), but they did not seem interested. Thus, I hand-optimize these particular issues instead.

The solution to Closure Compiler with my libraries is to provide the code minified by Closure Compiler to UglifyJS. UglifyJS shouldn't increase the file size (of the files already minified by closure compiler) too much, so using the minified files as the source files ought to be a fair compromise.

Further, another reason for these dropbox links is that they allow me to distribute new versions of the libraries for bug fixes and updating the size here on microjs. This may sound evil, but really I assure you it is not. I have no big plans or intentions for any of these libraries, so any new changes that I would post up would only be bug fixes. I would never post up breaking changes for any of these libraries.

To conclude, I petition the inclusion of my libraries into the MicroJS list because of the fact that all of my libraries in this pull request are under 5kb before gzip.