### PR TITLE
Add pqm

### DIFF
--- a/data.js
+++ b/data.js
@@ -3364,6 +3364,13 @@ module.exports = [
     url: "https://github.com/sandeepjain/fayer",
     source: "https://raw.githubusercontent.com/sandeepjain/fayer/master/src/fayer.js"
   },
+  {
+    name: "pqm",
+    tags: ["units", "physics", "quantities", "dimensions"],
+    description: "Physical Quantities and Measures (PQM) is a Node and browser package for dealing with numbers with units",
+    url: "https://github.com/GhostWrench/pqm",
+    source: "https://raw.githubusercontent.com/GhostWrench/pqm/master/build/cjs/pqm.cjs"
+  },
   /* versioned releases, removed
   {
     name: "Supplement.js",


### PR DESCRIPTION
PQM stands for Physical Quantities and Measures and is a package that allows users to define, convert, compare, and do math with numbers with units (physical quantities). Supports over 180 units, and is ~ 1/2 the size and 2x the performance of similar packages.