### PR TITLE
Add tint to the list

### DIFF
--- a/data.js
+++ b/data.js
@@ -5983,5 +5983,12 @@ module.exports = [
     description: "Aspect-oriented reactive DOM framework",
     url: "https://github.com/spectjs/spect",
     source: "https://raw.githubusercontent.com/spectjs/spect/master/spect.js"
+  },  {
+    name: "tint",
+    github: " marcodpt/tint",
+    tags: ["html", "template", "virtual-dom", "vuejs", "spa", "template-engine", "thymeleaf", "dom", "xml", "mustache", "template-language", "handlebars", "html-template", "rivets", "transparency", "dom-templating", "natural", "hyperapp", "xml-template", "logic-less"],
+    description: "A browser-based template engine that compiles all template tags into hyperscript functions. It works with all frameworks that use hyperscript. ",
+    url: "https://github.com/marcodpt/tint",
+    source: "https://raw.githubusercontent.com/marcodpt/tint/main/index.js"
   },
 ];


### PR DESCRIPTION
[tint](https://github.com/marcodpt/tint) is a template engine. And you are very clear about the template engines in README.md. I agree with that.

The reason I insist on this pull request is that [tint](https://github.com/marcodpt/tint) is not a normal template engine. It doesn't render the result to a string, it compiles all the html5 templates tag in the current page to [hyperscript](https://github.com/hyperhype/hyperscript) functions. This is a very niche usage.

There are many frameworks like [hyperapp](https://github.com/jorgebucaran/hyperapp), [superfine](https://github.com/jorgebucaran/superfine), [mithril](https://github.com/MithrilJS/mithril.js/), [preact](https://github.com/preactjs/preact), etc that use [hyperscript](https://github.com/hyperhype/hyperscript) to create their own views.

And using [hyperscript](https://github.com/hyperhype/hyperscript) to create views is quite confusing for designers. This is a topic of much discussion in the community of these frameworks.

This is a very beautiful, small and specific software that I believe its dissemination will bring great benefits to the community of these frameworks. And also to transform static templates into dynamic templates as it also can be used as a normal template engine.